### PR TITLE
Remove unused env 'unit'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
 
 script:
   - tox -e pep8
-  - tox -e unit
+  - tox -e py27
   - tox -e unit_integration
   - tox -e integration etc/template.yaml
   - tox -e cover

--- a/tools/pretty_tox.sh
+++ b/tools/pretty_tox.sh
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-set -o pipefail
-
-TESTRARGS=$1
-python setup.py testr --slowest --testr-args="--subunit $TESTRARGS"

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ setenv =
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
-commands = python setup.py testr '{postargs}'
+commands = python setup.py testr
 whitelist_externals = bash
 
 [testenv:unit_integration]

--- a/tox.ini
+++ b/tox.ini
@@ -10,14 +10,8 @@ setenv =
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
-commands = bash tools/pretty_tox.sh '{posargs}'
+commands = python setup.py testr '{postargs}'
 whitelist_externals = bash
-
-[testenv:unit]
-setenv =
-    VIRTUAL_ENV={envdir}
-    DISCOVER_DIRECTORY=shellper/tests/unit
-commands = python setup.py testr
 
 [testenv:unit_integration]
 setenv =


### PR DESCRIPTION
Refactor tox.ini. Remove 'unit' env.
Migrate unit-tests to 'py27' env
closes #61